### PR TITLE
Optimize Filling Logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ $pool = new Pool('mysql-pool', 1 /* number of connections */, function() {
 $pool->setReconnectAttempts(3); // number of attempts to reconnect
 $pool->setReconnectSleep(5); // seconds to sleep between reconnect attempts
 
-$pool->fill(); // Populate the pool with connections
-
 $connection = $pool->pop(); // Get a connection from the pool
 $connection->getID(); // Get the connection ID
 $connection->getResource(); // Get the connection resource

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "php": ">=8.0",
         "ext-pdo": "*",
         "ext-redis": "*",
-        "ext-mongodb": "*"
+        "ext-mongodb": "*",
+        "utopia-php/cli": "^0.11.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.4",

--- a/src/Pools/Connection.php
+++ b/src/Pools/Connection.php
@@ -10,6 +10,11 @@ class Connection {
     protected string $id = '';
 
     /**
+     * @var Pool
+     */
+    protected ?Pool $pool = null;
+
+    /**
      * @var mixed $resource
      */
     public function __construct(protected mixed $resource)
@@ -50,5 +55,31 @@ class Connection {
     {
         $this->resource = $resource;
         return $this;
+    }
+
+    /**
+     * @return Pool
+     */
+    public function getPool(): ?Pool
+    {
+        return $this->pool;
+    }
+
+    /**
+     * @param Pool $pool
+     * @return self
+     */
+    public function setPool(Pool &$pool): self
+    {
+        $this->pool = $pool;
+        return $this;
+    }
+
+    /**
+     * @return Pool
+     */
+    public function reclaim(): Pool
+    {
+        return $this->pool->reclaim($this);
     }
 }

--- a/src/Pools/Group.php
+++ b/src/Pools/Group.php
@@ -39,19 +39,7 @@ class Group
         unset($this->pools[$name]);
         return $this;
     }
-    
-    /**
-     * @return self
-     */
-    public function fill(): self
-    {
-        foreach ($this->pools as $pool) {
-            $pool->fill();
-        }
-        
-        return $this;
-    }
-    
+
     /**
      * @return self
      */

--- a/src/Pools/Group.php
+++ b/src/Pools/Group.php
@@ -27,7 +27,7 @@ class Group
      */
     public function get(string $name): Pool
     {
-        return $this->pools[$name] ??  throw new Exception('Pool not found');
+        return $this->pools[$name] ??  throw new Exception("Pool '{$name}'  not found");
     }
 
     /**

--- a/src/Pools/Pool.php
+++ b/src/Pools/Pool.php
@@ -51,6 +51,7 @@ class Pool
         $this->name = $name;
         $this->size = $size;
         $this->init = $init;
+        $this->pool = array_fill(0, $size, true);
     }
 
     /**
@@ -106,13 +107,36 @@ class Pool
     }
 
     /**
-     * @return self
+     * Summary: 
+     *  1. Try to get a connection from the pool
+     *  2. If no connection is available, wait for one to be released
+     *  3. If still no connection is available, throw an exception
+     *  4. If a connection is available, return it
+     * 
+     *  1. Pool not at max size:
+     *      1.1 Available: Pop connection
+     *      1.2 Not Available: Create connection (x attempts or throw exception)
+     *  2. Pool is at max size: Wait (x seconds, y intervals)
+     *      2.1. Available: Return connection
+     *      2.1. Not Available: Throw exception
+     * 
+     * @return Connection
      */
-    public function fill(): self
+    public function pop(): Connection
     {
-        $this->pool = [];
+        $connection = array_pop($this->pool);
 
-        for ($i=0; $i < $this->size; $i++) { 
+        if(is_null($connection)) { // pool is empty, wait an if still empty throw exception
+            usleep(50000); // 50ms TODO: make this configurable
+
+            $connection = array_pop($this->pool);
+
+            if(is_null($connection)) {
+                throw new Exception('Pool is empty');
+            }
+        }
+
+        if($connection === true) { // Pool has space, create connection
             $attempts = 0;
 
             do {
@@ -129,37 +153,17 @@ class Pool
             } while ($attempts < $this->getReconnectAttempts());
 
             $connection
-                ->setID($this->getName().'-'.$i)
+                ->setID($this->getName().'-'.uniqid())
                 ->setPool($this)
             ;
-            
-            $this->pool[$i] = $connection;
+        }
+        
+        if($connection instanceof Connection) { // connection is available, return it
+            $this->active[$connection->getID()] = $connection;
+            return $connection;
         }
 
-        return $this;
-    }
-
-    /**
-     * Summary: 
-     *  1. Pool not at max size:
-     *      1.1 Available: Pop connection
-     *      1.2 Not Available: Create connection (x attempts or throw exception)
-     *  2. Pool is at max size: Wait (x seconds, y intervals)
-     *      2.1. Available: Return connection
-     *      2.1. Not Available: Throw exception
-     * 
-     * @return Connection
-     */
-    public function pop(): Connection
-    {
-        if (empty($this->pool)) {
-            throw new Exception('Pool is empty');
-        }
-
-        $connection = array_pop($this->pool);
-        $this->active[$connection->getID()] = $connection;
-
-        return $connection;
+        throw new Exception('Failed to pop a connection from the pool');
     }
 
     /**

--- a/src/Pools/Pool.php
+++ b/src/Pools/Pool.php
@@ -156,7 +156,7 @@ class Pool
             return $connection;
         }
 
-        throw new Exception('Failed to pop a connection from the pool');
+        throw new Exception('Failed to get a connection from the pool');
     }
 
     /**

--- a/src/Pools/Pool.php
+++ b/src/Pools/Pool.php
@@ -128,7 +128,10 @@ class Pool
                 }
             } while ($attempts < $this->getReconnectAttempts());
 
-            $connection->setID($this->getName().'-'.$i);
+            $connection
+                ->setID($this->getName().'-'.$i)
+                ->setPool($this)
+            ;
             
             $this->pool[$i] = $connection;
         }
@@ -137,6 +140,14 @@ class Pool
     }
 
     /**
+     * Summary: 
+     *  1. Pool not at max size:
+     *      1.1 Available: Pop connection
+     *      1.2 Not Available: Create connection (x attempts or throw exception)
+     *  2. Pool is at max size: Wait (x seconds, y intervals)
+     *      2.1. Available: Return connection
+     *      2.1. Not Available: Throw exception
+     * 
      * @return Connection
      */
     public function pop(): Connection

--- a/src/Pools/Pool.php
+++ b/src/Pools/Pool.php
@@ -113,13 +113,6 @@ class Pool
      *  3. If still no connection is available, throw an exception
      *  4. If a connection is available, return it
      * 
-     *  1. Pool not at max size:
-     *      1.1 Available: Pop connection
-     *      1.2 Not Available: Create connection (x attempts or throw exception)
-     *  2. Pool is at max size: Wait (x seconds, y intervals)
-     *      2.1. Available: Return connection
-     *      2.1. Not Available: Throw exception
-     * 
      * @return Connection
      */
     public function pop(): Connection

--- a/tests/Pools/ConnectionTest.php
+++ b/tests/Pools/ConnectionTest.php
@@ -4,6 +4,7 @@ namespace Utopia\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Utopia\Pools\Connection;
+use Utopia\Pools\Pool;
 
 class ConnectionTest extends TestCase
 {
@@ -49,5 +50,46 @@ class ConnectionTest extends TestCase
         $this->assertInstanceOf(Connection::class, $this->object->setResource('y'));
         
         $this->assertEquals('y', $this->object->getResource());
+    }
+
+    public function testSetPool()
+    {
+        $pool = new Pool('test', 1, function () {
+            return 'x';
+        });
+
+        $this->assertNull($this->object->getPool());
+        $this->assertInstanceOf(Connection::class, $this->object->setPool($pool));
+    }
+
+    public function testGetPool()
+    {
+        $pool = new Pool('test', 1, function () {
+            return 'x';
+        });
+
+        $this->assertNull($this->object->getPool());
+        $this->assertInstanceOf(Connection::class, $this->object->setPool($pool));
+        $this->assertInstanceOf(Pool::class, $this->object->getPool());
+        $this->assertEquals('test', $this->object->getPool()->getName());
+    }
+
+    public function testReclame()
+    {
+        $pool = new Pool('test', 1, function () {
+            return 'x';
+        });
+
+        $pool->fill();
+
+        $this->assertEquals(1, $pool->count());
+
+        $connection = $pool->pop();
+
+        $this->assertEquals(0, $pool->count());
+     
+        $this->assertInstanceOf(Pool::class, $connection->reclaim());
+     
+        $this->assertEquals(1, $pool->count());
     }
 }

--- a/tests/Pools/ConnectionTest.php
+++ b/tests/Pools/ConnectionTest.php
@@ -80,8 +80,6 @@ class ConnectionTest extends TestCase
             return 'x';
         });
 
-        $pool->fill();
-
         $this->assertEquals(1, $pool->count());
 
         $connection = $pool->pop();

--- a/tests/Pools/GroupTest.php
+++ b/tests/Pools/GroupTest.php
@@ -59,34 +59,11 @@ class GroupTest extends TestCase
         $this->assertInstanceOf(Pool::class, $this->object->get('test'));
     }
 
-    public function testFill()
-    {
-        $this->object->add(new Pool('test', 1, function() {
-            return 'x';
-        }));
-
-        // Pool should be empty
-        try {
-            $this->object->get('test')->pop();
-            $this->fail('Exception not thrown');
-        } catch (Exception $e) {
-            $this->assertInstanceOf(Exception::class, $e);
-        }
-
-        $this->object->fill();
-
-        $this->assertInstanceOf(Connection::class, $this->object->get('test')->pop());
-    }
-
     public function testReset()
     {
         $this->object->add(new Pool('test', 5, function() {
             return 'x';
         }));
-
-        $this->assertEquals(0, $this->object->get('test')->count());
-
-        $this->object->fill();
 
         $this->assertEquals(5, $this->object->get('test')->count());
 

--- a/tests/Pools/PoolTest.php
+++ b/tests/Pools/PoolTest.php
@@ -61,48 +61,17 @@ class PoolTest extends TestCase
         $this->assertEquals(20, $this->object->getReconnectSleep());
     }
 
-    public function testFill()
-    {
-        $this->assertEquals(0, $this->object->count());
-        
-        $this->object->fill();
-
-        $this->assertEquals(5, $this->object->count());
-    }
-
-    public function testFillFailure()
-    {
-        $this->object = new Pool('test', 5, function() {
-            throw new Exception();
-        });
-
-        $start = microtime(true);
-
-        $this->assertEquals(0, $this->object->count());
-        
-        try {
-            $this->object->fill();
-            $this->fail('Exception not thrown');
-        } catch (Exception $e) {
-            $this->assertInstanceOf(Exception::class, $e);
-        }
-    
-        $time = microtime(true) - $start;
-
-        $this->assertGreaterThan(2, $time);
-    }
-
     public function testPop()
     {
-        // Pool should be empty
-        try {
-            $this->object->pop();
-            $this->fail('Exception not thrown');
-        } catch (Exception $e) {
-            $this->assertInstanceOf(Exception::class, $e);
-        }
+        // // Pool should be empty
+        // try {
+        //     $this->object->pop();
+        //     $this->fail('Exception not thrown');
+        // } catch (Exception $e) {
+        //     $this->assertInstanceOf(Exception::class, $e);
+        // }
 
-        $this->object->fill();
+        // $this->object->fill();
 
         $this->assertEquals(5, $this->object->count());
 
@@ -116,16 +85,6 @@ class PoolTest extends TestCase
 
     public function testPush()
     {
-        // Pool should be empty
-        try {
-            $this->object->pop();
-            $this->fail('Exception not thrown');
-        } catch (Exception $e) {
-            $this->assertInstanceOf(Exception::class, $e);
-        }
-
-        $this->object->fill();
-
         $this->assertEquals(5, $this->object->count());
 
         $connection = $this->object->pop();
@@ -142,10 +101,6 @@ class PoolTest extends TestCase
 
     public function testCount()
     {
-        $this->assertEquals(0, $this->object->count());
-     
-        $this->object->fill();
-
         $this->assertEquals(5, $this->object->count());
 
         $connection = $this->object->pop();
@@ -157,12 +112,8 @@ class PoolTest extends TestCase
         $this->assertEquals(5, $this->object->count());
     }
 
-    public function testReset()
+    public function testReclaim()
     {
-        $this->assertEquals(0, $this->object->count());
-
-        $this->object->fill();
-
         $this->assertEquals(5, $this->object->count());
 
         $this->object->pop();
@@ -178,12 +129,6 @@ class PoolTest extends TestCase
 
     public function testIsEmpty()
     {
-        $this->assertEquals(true, $this->object->isEmpty());
-
-        $this->object->fill();
-
-        $this->assertEquals(false, $this->object->isEmpty());
-
         $this->object->pop();
         $this->object->pop();
         $this->object->pop();
@@ -195,10 +140,6 @@ class PoolTest extends TestCase
 
     public function testIsFull()
     {
-        $this->assertEquals(false, $this->object->isFull());
-
-        $this->object->fill();
-
         $this->assertEquals(true, $this->object->isFull());
 
         $connection = $this->object->pop();
@@ -228,9 +169,5 @@ class PoolTest extends TestCase
         $this->object->pop();
 
         $this->assertEquals(false, $this->object->isFull());
-
-        $this->object->fill();
-
-        $this->assertEquals(true, $this->object->isFull());
     }
 }

--- a/tests/Pools/PoolTest.php
+++ b/tests/Pools/PoolTest.php
@@ -63,16 +63,6 @@ class PoolTest extends TestCase
 
     public function testPop()
     {
-        // // Pool should be empty
-        // try {
-        //     $this->object->pop();
-        //     $this->fail('Exception not thrown');
-        // } catch (Exception $e) {
-        //     $this->assertInstanceOf(Exception::class, $e);
-        // }
-
-        // $this->object->fill();
-
         $this->assertEquals(5, $this->object->count());
 
         $connection = $this->object->pop();
@@ -81,6 +71,15 @@ class PoolTest extends TestCase
 
         $this->assertInstanceOf(Connection::class, $connection);
         $this->assertEquals('x', $connection->getResource());
+
+        // // Pool should be empty
+        $this->expectException(Exception::class);
+
+        $this->assertInstanceOf(Connection::class, $this->object->pop());
+        $this->assertInstanceOf(Connection::class, $this->object->pop());
+        $this->assertInstanceOf(Connection::class, $this->object->pop());
+        $this->assertInstanceOf(Connection::class, $this->object->pop());
+        $this->assertInstanceOf(Connection::class, $this->object->pop());
     }
 
     public function testPush()


### PR DESCRIPTION
- [x] Fill pool only on demand, stop pre-filling the entire queue
- [x] Reclaim a single connection
- [x] Deprecate `->fill()`
- [x] Add timeout logic in case the queue is empty and max connections are used (no ability to create new ones)