### PR TITLE
exposed use time metric for a failure a connection as well

### DIFF
--- a/src/Pools/Pool.php
+++ b/src/Pools/Pool.php
@@ -229,8 +229,8 @@ class Pool
             $connection = $this->pop();
             return $callback($connection->getResource());
         } finally {
+            $this->telemetryUseDuration->record(microtime(true) - $start, $this->telemetryAttributes);
             if ($connection !== null) {
-                $this->telemetryUseDuration->record(microtime(true) - $start, $this->telemetryAttributes);
                 $this->reclaim($connection);
             }
         }


### PR DESCRIPTION
Use time metric wasn't exposing the use time for a error specific connection -> hiding details
So exposed for every use operation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of performance monitoring by ensuring telemetry is recorded uniformly across all database pool operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->