### PR TITLE
Fix pool exhaustion: retry on creation failure, add diagnostics

### DIFF
--- a/src/Pools/Pool.php
+++ b/src/Pools/Pool.php
@@ -251,6 +251,7 @@ class Pool
     {
         $attempts = 0;
         $totalSleepTime = 0;
+        $lastException = null;
 
         try {
             do {
@@ -279,7 +280,9 @@ class Pool
                         $this->pool->synchronized(function () {
                             $this->connectionsCreated--;
                         });
-                        throw $e;
+                        // Don't throw immediately - fall through to try getting
+                        // an existing connection from the pool
+                        $lastException = $e;
                     }
                 }
 
@@ -287,7 +290,10 @@ class Pool
 
                 if ($connection === false || $connection === null) {
                     if ($attempts >= $this->getRetryAttempts()) {
-                        throw new Exception("Pool '{$this->name}' is empty (size {$this->size})");
+                        $activeCount = count($this->active);
+                        $idleCount = $this->pool->count();
+                        $message = "Pool '{$this->name}' is empty (size {$this->size}, active {$activeCount}, idle {$idleCount})";
+                        throw new Exception($message, 0, $lastException);
                     }
 
                     $totalSleepTime += $this->getRetrySleep();
@@ -302,7 +308,9 @@ class Pool
                 }
             } while ($attempts < $this->getRetryAttempts());
 
-            throw new Exception('Failed to get a connection from the pool');
+            $activeCount = count($this->active);
+            $idleCount = $this->pool->count();
+            throw new Exception("Pool '{$this->name}' failed to provide a connection (size {$this->size}, active {$activeCount}, idle {$idleCount})", 0, $lastException);
         } finally {
             $this->recordPoolTelemetry();
             $this->telemetryWaitDuration->record($totalSleepTime, $this->telemetryAttributes);

--- a/tests/Pools/Scopes/PoolTestScope.php
+++ b/tests/Pools/Scopes/PoolTestScope.php
@@ -318,6 +318,72 @@ trait PoolTestScope
         });
     }
 
+    public function testPopRetriesAfterConnectionCreationFailure(): void
+    {
+        $this->execute(function (): void {
+            $callCount = 0;
+            $pool = new Pool($this->getAdapter(), 'test-retry', 1, function () use (&$callCount) {
+                $callCount++;
+                if ($callCount <= 1) {
+                    throw new \Exception('Connection failed');
+                }
+                return 'x';
+            });
+            $pool->setReconnectAttempts(1);
+            $pool->setReconnectSleep(0);
+            $pool->setRetrySleep(0);
+
+            // With the fix, pop() should retry after creation failure
+            // First attempt: createConnection fails (callCount=1), falls through
+            // Second attempt: createConnection succeeds (callCount=2)
+            $connection = $pool->pop();
+            $this->assertSame('x', $connection->getResource());
+        });
+    }
+
+    public function testPoolEmptyErrorIncludesActiveCount(): void
+    {
+        $this->execute(function (): void {
+            $this->setUpPool(); // size 5
+            $this->poolObject->setRetryAttempts(1);
+            $this->poolObject->setRetrySleep(0);
+
+            // Pop all 5
+            $this->poolObject->pop();
+            $this->poolObject->pop();
+            $this->poolObject->pop();
+            $this->poolObject->pop();
+            $this->poolObject->pop();
+
+            try {
+                $this->poolObject->pop();
+                $this->fail('Should have thrown');
+            } catch (Exception $e) {
+                $this->assertStringContainsString('active 5', $e->getMessage());
+            }
+        });
+    }
+
+    public function testUseReclainsConnectionOnCallbackException(): void
+    {
+        $this->execute(function (): void {
+            $this->setUpPool(); // size 5
+
+            // use() should reclaim the connection even when callback throws
+            try {
+                $this->poolObject->use(function ($resource): void {
+                    $this->assertSame(4, $this->poolObject->count());
+                    throw new \RuntimeException('Callback failed');
+                });
+            } catch (\RuntimeException) {
+                // expected
+            }
+
+            // Connection should be reclaimed, pool back to full
+            $this->assertSame(5, $this->poolObject->count());
+        });
+    }
+
     public function testPoolTelemetry(): void
     {
         $this->execute(function (): void {


### PR DESCRIPTION
## Summary
- **Fix connection creation failure handling**: When `createConnection()` fails in `pop()`, the method now falls through to the retry loop instead of throwing immediately. This allows the pool to recover from transient connection failures by retrying creation on subsequent attempts.
- **Add diagnostic info to error messages**: The "Pool is empty" error now includes active and idle connection counts (e.g., `Pool 'console' is empty (size 75, active 75, idle 0)`), making it easy to distinguish pool capacity issues from connection leaks.
- **Chain exceptions**: When connection creation failure leads to pool exhaustion, the original creation exception is chained as the previous exception for better debugging.

Fixes: CLOUD-3K4N (Pool 'console' is empty, 3267 events)

## Test plan
- [x] Added `testPopRetriesAfterConnectionCreationFailure` - verifies pool retries after transient creation failure
- [x] Added `testPoolEmptyErrorIncludesActiveCount` - verifies error message includes active/idle counts
- [x] Added `testUseReclainsConnectionOnCallbackException` - verifies `use()` reclaims on callback failure
- [x] All 84 existing tests pass
- [x] PHPStan static analysis passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Connection pool error messages now include pool size and active connection counts for better diagnostics
  * Root cause exceptions are properly preserved and chained when connection operations fail after retries

* **Tests**
  * Added test coverage for connection creation retry behavior, error messaging accuracy, and connection reclamation on callback failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->