### PR TITLE
fix: surface last connection error in pool exhaustion messages

### DIFF
--- a/src/Pools/Pool.php
+++ b/src/Pools/Pool.php
@@ -294,7 +294,7 @@ class Pool
                     if ($attempts >= $this->getRetryAttempts()) {
                         $activeCount = count($this->active);
                         $idleCount = $this->pool->count();
-                        $message = "Pool '{$this->name}' is empty (size {$this->size}, active {$activeCount}, idle {$idleCount})";
+                        $message = "Pool '{$this->name}' is empty (size {$this->size}, active {$activeCount}, idle {$idleCount})" . $this->lastError($lastException);
                         throw new Exception($message, 0, $lastException);
                     }
 
@@ -312,11 +312,26 @@ class Pool
 
             $activeCount = count($this->active);
             $idleCount = $this->pool->count();
-            throw new Exception("Pool '{$this->name}' failed to provide a connection (size {$this->size}, active {$activeCount}, idle {$idleCount})", 0, $lastException);
+            throw new Exception("Pool '{$this->name}' failed to provide a connection (size {$this->size}, active {$activeCount}, idle {$idleCount})" . $this->lastError($lastException), 0, $lastException);
         } finally {
             $this->recordPoolTelemetry();
             $this->telemetryWaitDuration->record($totalSleepTime, $this->telemetryAttributes);
         }
+    }
+
+    /**
+     * Format the most recent connection-creation failure for inclusion in a
+     * pool exhaustion message, so the underlying cause (for example a TLS or
+     * timeout failure from the backend) is not swallowed by the generic
+     * "pool is empty" message.
+     */
+    private function lastError(?\Exception $exception): string
+    {
+        if ($exception === null) {
+            return '';
+        }
+
+        return "; last error: {$exception->getMessage()}";
     }
 
     /**
@@ -336,7 +351,7 @@ class Pool
                 break;
             } catch (\Exception $e) {
                 if ($attempts >= $this->getReconnectAttempts()) {
-                    throw new \Exception('Failed to create connection: ' . $e->getMessage());
+                    throw new \Exception('Failed to create connection: ' . $e->getMessage(), 0, $e);
                 }
                 sleep($this->getReconnectSleep());
             }

--- a/tests/Pools/Scopes/PoolTestScope.php
+++ b/tests/Pools/Scopes/PoolTestScope.php
@@ -142,6 +142,50 @@ trait PoolTestScope
         });
     }
 
+    public function testPoolPopEmptyMessageIncludesLastConnectionError(): void
+    {
+        $this->execute(function (): void {
+            $pool = new Pool($this->getAdapter(), 'broken', 1, function (): string {
+                throw new Exception('connection to server failed: TLS alert');
+            });
+            $pool->setReconnectAttempts(1);
+            $pool->setReconnectSleep(0);
+            $pool->setRetryAttempts(1);
+            $pool->setRetrySleep(0);
+            $pool->setSynchronizationTimeout(1);
+
+            try {
+                $pool->pop();
+                $this->fail('pop() must throw when every connection attempt fails');
+            } catch (Exception $e) {
+                $this->assertStringContainsString("Pool 'broken' is empty (size 1, active 0, idle 0)", $e->getMessage());
+                $this->assertStringContainsString('last error: Failed to create connection: connection to server failed: TLS alert', $e->getMessage());
+                $this->assertNotNull($e->getPrevious());
+                $this->assertSame('connection to server failed: TLS alert', $e->getPrevious()->getPrevious()?->getMessage());
+            }
+        });
+    }
+
+    public function testPoolPopEmptyMessageOmitsLastErrorWithoutConnectionFailure(): void
+    {
+        $this->execute(function (): void {
+            $pool = new Pool($this->getAdapter(), 'exhausted', 1, fn () => 'x');
+            $pool->setRetryAttempts(1);
+            $pool->setRetrySleep(0);
+            $pool->setSynchronizationTimeout(1);
+
+            $pool->pop();
+
+            try {
+                $pool->pop();
+                $this->fail('pop() must throw when the pool is exhausted');
+            } catch (Exception $e) {
+                $this->assertStringNotContainsString('last error', $e->getMessage());
+                $this->assertNull($e->getPrevious());
+            }
+        });
+    }
+
     public function testPoolUse(): void
     {
         $this->execute(function (): void {


### PR DESCRIPTION
## What

When every connection attempt fails, `Pool::pop()` throws the generic `Pool '<name>' is empty (size N, active 0, idle 0)` message. The underlying connect failure is chained as `previous` but never shown, so consumers that log only the exception message have no way to see why the pool never filled.

Seen live during DAT-1556 (appwrite-labs/cloud): a dedicated-database schema bootstrap retried for minutes against `Pool 'db-{hash}.fra.appwrite.center' is empty (size 10, active 0, idle 0)` while the actual cause — libpq's TLS negotiation hanging against the databases front — was invisible.

## Changes

- Remember the last connection-creation failure in `pop()` and append it to both exhaustion messages: `... is empty (size 10, active 0, idle 0); last error: Failed to create connection: <cause>`. Messages without a connect failure (plain exhaustion) are unchanged.
- Chain the original exception through the `createConnection()` wrapper (`previous`), so the full cause survives via `getPrevious()` end to end.

## Tests

- `testPoolPopEmptyMessageIncludesLastConnectionError` — failing init: message carries the cause, previous chain intact (Stack + Swoole adapters).
- `testPoolPopEmptyMessageOmitsLastErrorWithoutConnectionFailure` — plain exhaustion: message unchanged, no previous.

Pairs with the appwrite-labs/cloud PR for DAT-1556 (cloud picks this up via a patch release once merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)